### PR TITLE
Add environment variable parsing to the runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use the following YAML file:
 ```yaml
 # find.yaml
 find:
-  - "/var/log"
+  - "$NOF_EXAMPLE_DIR"
   - "*.log"
   - "-mtime"
   - "-3"
@@ -31,7 +31,7 @@ find:
 Then run:
 
 ```
-nof ./examples/find.yaml
+export NOF_EXAMPLE_DIR=/var/log && ./nof run ./examples/find.yaml
 ```
 
 ## Installation

--- a/examples/find.yaml
+++ b/examples/find.yaml
@@ -1,5 +1,5 @@
 find:
-  - "/var/log"
+  - "$NOF_EXAMPLE_DIR"
   - "*.log"
   - "-mtime"
   - "-3"

--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -1,4 +1,0 @@
-go:
-  - "run"
-  - "main.go"
-  - "example/find.yaml"

--- a/internal/yaml.go
+++ b/internal/yaml.go
@@ -1,9 +1,32 @@
 package internal
 
 import (
-	"gopkg.in/yaml.v3"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
 )
+
+func ProcessArgs(args []string) ([]string, error) {
+	for i, arg := range args {
+		re := regexp.MustCompile("(.*?)\\s(.*?)")
+		found := re.Find([]byte(arg))
+		if found != nil {
+			return []string{}, errors.New(fmt.Sprintf("Variable can't contian any whitespace: '%s'", arg))
+		}
+		if string(arg[0]) == "$" {
+			cmdVar := arg[1:]
+			value := os.Getenv(cmdVar)
+			if value != "" {
+				args[i] = value
+			}
+		}
+	}
+	return args, nil
+}
 
 func (c *Command) UnmarshalYAML(value *yaml.Node) error {
 	var raw map[string][]string
@@ -11,14 +34,18 @@ func (c *Command) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	for k, v := range raw {
+		processed_args, err := ProcessArgs(v)
+		if err != nil {
+			return err
+		}
 		c.Name = k
-		c.Args = v
+		c.Args = processed_args
 		break
 	}
 	return nil
 }
 
-func (c Command) MarshalYAML() (interface{}, error) {
+func (c Command) MarshalYAML() (any, error) {
 	return map[string][]string{
 		c.Name: c.Args,
 	}, nil
@@ -28,5 +55,6 @@ func CommandToExec(command *Command) *exec.Cmd {
 	name := command.Name
 	args := command.Args
 	cmd := exec.Command(name, args...)
+	cmd.Env = os.Environ()
 	return cmd
 }


### PR DESCRIPTION
- environment variables are added to the `cmd.Env`
- variables starting with `$` are parsed as environment variable and have their value passed to exec
- unit tests for the new features
- extra: Fix/update README